### PR TITLE
colorize LogStash::Timestamp as green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.2
+ - Colorize LogStash::Timestamp as green
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/codecs/rubydebug.rb
+++ b/lib/logstash/codecs/rubydebug.rb
@@ -12,6 +12,7 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
 
   def register
     require "awesome_print"
+    AwesomePrint.defaults = { :color => { :logstash_timestamp => :green } }
     if @metadata
       @encoder = method(:encode_with_metadata)
     else

--- a/logstash-codec-rubydebug.gemspec
+++ b/logstash-codec-rubydebug.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-rubydebug'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The rubydebug codec will output your Logstash event data using the Ruby Awesome Print library."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
until `@timestamp` became a LogStash::Timestamp instead of a Time object
awesome_print colored it green. This PR replicates the old behaviour for
the new logstash timestamp class

fixes #5