### PR TITLE
remove Timestamp coloring, feature not testable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+## 2.0.4
+ - remove LogStash::Timestamp coloring
 ## 2.0.3
  - Colorize LogStash::Timestamp as green
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/lib/logstash/codecs/rubydebug.rb
+++ b/lib/logstash/codecs/rubydebug.rb
@@ -10,9 +10,14 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
   # Should the event's metadata be included?
   config :metadata, :validate => :boolean, :default => false
 
+  # AWESOME_OPTIONS = {:color => {:logstash_timestamp => :green}}
+  # disabled options, for some reason the timnestamp coloring is boggus only occurs once and is not testable.
+  AWESOME_OPTIONS = {}
+
   def register
     require "awesome_print"
-    AwesomePrint.defaults = { :color => { :logstash_timestamp => :green } }
+    AwesomePrint.defaults = AWESOME_OPTIONS
+
     if @metadata
       @encoder = method(:encode_with_metadata)
     else

--- a/lib/logstash/codecs/rubydebug.rb
+++ b/lib/logstash/codecs/rubydebug.rb
@@ -11,7 +11,7 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
   config :metadata, :validate => :boolean, :default => false
 
   # AWESOME_OPTIONS = {:color => {:logstash_timestamp => :green}}
-  # disabled options, for some reason the timnestamp coloring is boggus only occurs once and is not testable.
+  # disabled options, awesome_print coloring option is buggy and only occurs once and it cannot be tested.
   AWESOME_OPTIONS = {}
 
   def register

--- a/logstash-codec-rubydebug.gemspec
+++ b/logstash-codec-rubydebug.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-rubydebug'
-  s.version         = '2.0.3'
+  s.version         = '2.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The rubydebug codec will output your Logstash event data using the Ruby Awesome Print library."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/rubydebug_spec.rb
+++ b/spec/codecs/rubydebug_spec.rb
@@ -1,26 +1,22 @@
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/rubydebug"
 require "logstash/event"
-require "awesome_print"
-require "insist"
 
 describe LogStash::Codecs::RubyDebug do
 
-
-  subject do
-    next LogStash::Codecs::RubyDebug.new
-  end
+  subject { LogStash::Codecs::RubyDebug.new }
 
   context "#encode" do
     it "should print beautiful hashes" do
-      test_event = LogStash::Event.new({"what" => "ok", "who" => 2})
-      got_event = false
-      subject.on_event do |e, d|
-        insist { d.chomp } == test_event.to_hash.awesome_inspect 
-        got_event = true
-      end
-      subject.encode(test_event)
-      insist { got_event }
+      subject.register
+
+      event = LogStash::Event.new({"what" => "ok", "who" => 2})
+      on_event = lambda { |e, d| expect(d.chomp).to eq(event.to_hash.awesome_inspect) }
+
+      subject.on_event(&on_event)
+      expect(on_event).to receive(:call).once.and_call_original
+
+      subject.encode(event)
     end
   end
 


### PR DESCRIPTION
for unknow reasons `awesome_print` is buggy and an `Event#to_hash.awesome_inspect` does not systematically produce the same result when using the custom `Timestamp` coloring options.

After spending some time trying to figure the probleme I just decided to turn off coloring of the Timestamp  so that this plugin be testable again.

@jsvd since you are the one that put back coloring in #5 and #6 , can you please check this and either find the solution to have it testable otherwise accept this PR?

I do not believe Timestamp coloring is crutial. 