### PR TITLE
Dont do a strict comparison for the generated string

### DIFF
--- a/spec/codecs/rubydebug_spec.rb
+++ b/spec/codecs/rubydebug_spec.rb
@@ -26,8 +26,13 @@ describe LogStash::Codecs::RubyDebug do
     it "should print beautiful hashes" do
       subject.register
 
-      event = LogStash::Event.new({"what" => "ok", "who" => 2})
-      on_event = lambda { |e, d| expect(d.chomp).to eq(event.to_hash.awesome_inspect) }
+      event = LogStash::Event.new({"what" => "ok", "who" => 2222})
+
+      on_event = lambda do |e, d|
+        expect(d.chomp).to match(/\"ok\"/)
+        expect(d.chomp).to match(/2222/)
+        expect(d.chomp).to match(/@timestamp/)
+      end
 
       subject.on_event(&on_event)
       expect(on_event).to receive(:call).once.and_call_original


### PR DESCRIPTION
Calling Event.get("@timestamp") will return a new instance everytime
making the strict assert fails.

```
[1] pry(#<RSpec::ExampleGroups::LogStashCodecsRubyDebug::Encode>)> event.get("@timestamp")
=> #<LogStash::Timestamp:0x4b5cdd07>
[2] pry(#<RSpec::ExampleGroups::LogStashCodecsRubyDebug::Encode>)> event.get("@timestamp")
=> #<LogStash::Timestamp:0x70df41f9>
[3] pry(#<RSpec::ExampleGroups::LogStashCodecsRubyDebug::Encode>)> event.get("@timestamp")
=> #<LogStash::Timestamp:0x64a7ad02>
[4] pry(#<RSpec::ExampleGroups::LogStashCodecsRubyDebug::Encode>)> event.get("@timestamp")
```

Fix: #13 
