### PR TITLE
Sort keys by default

### DIFF
--- a/lib/logstash/codecs/rubydebug.rb
+++ b/lib/logstash/codecs/rubydebug.rb
@@ -12,7 +12,7 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
 
   # AWESOME_OPTIONS = {:color => {:logstash_timestamp => :green}}
   # disabled options, awesome_print coloring option is buggy and only occurs once and it cannot be tested.
-  AWESOME_OPTIONS = {}
+  AWESOME_OPTIONS = {:sort_keys => true}
 
   def register
     require "awesome_print"


### PR DESCRIPTION
Using AWESOME_OPTIONS, turned on sorting keys.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
