### PR TITLE
pin dependency `awesome_print` to v1.7.0 to avoid bug in v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.6
+ - Fixes crash that could occur on startup if `$HOME` was unset or if `${HOME}/.aprc` was unreadable by pinning `awesome_print` dependency to a release before the bug was introduced.
+
 ## 3.0.5
   - Update gemspec summary
 

--- a/logstash-codec-rubydebug.gemspec
+++ b/logstash-codec-rubydebug.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-rubydebug'
-  s.version         = '3.0.5'
+  s.version         = '3.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Applies the Ruby Awesome Print library to Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,13 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  s.add_runtime_dependency 'awesome_print'
+  # 2018-06-04: as of this writing, the latest release of awesome_print (v1.8.0) contains a bug that causes the Logstash
+  # process to crash while loading this dependency if an exception is raised attempting to load defaults (e.g., when
+  # `ENV['HOME']` is unset or the JVM doesn't have permission to read the `.aprc` file at that address).
+  #
+  # Pin to 1.7.0 until the already-fixed code on awesome_print's master branch finds its way to a release.
+  # SEE: https://github.com/awesome-print/awesome_print/issues/338
+  s.add_runtime_dependency 'awesome_print', '1.7.0'
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
The `awesome_print` release v1.8.0 contains a bug that causes the Logstash
process to crash while loading if an exception is raised while the library
attempts to load its user-defined defaults from disk (this can occur if the
`HOME` environment variable is unset, or if the JVM fails to read the file
at `${HOME}/.aprc`).

While the bug has been [fixed][] on the `awesome_print` master branch, until
a release is rolled, pin our dependency to an earlier version to avoid the
bug.

A release of the fix upstream has been requested on 2018-05-02 via
https://github.com/awesome-print/awesome_print/issues/338 

[fixed]: https://github.com/awesome-print/awesome_print/commit/62033856f8ff083
