### PR TITLE
replace awesome_print with amazing_print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+- Replace stale awesome_print library with maintained fork called amazing_print.
+
 ## 3.0.6
  - Fixes crash that could occur on startup if `$HOME` was unset or if `${HOME}/.aprc` was unreadable by pinning `awesome_print` dependency to a release before the bug was introduced.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -21,7 +21,7 @@ include::{include_path}/plugin_header.asciidoc[]
 ==== Description
 
 The rubydebug codec will output your Logstash event data using
-the Ruby Awesome Print library.
+the Ruby Amazing Print library.
 
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/lib/logstash/codecs/rubydebug.rb
+++ b/lib/logstash/codecs/rubydebug.rb
@@ -10,7 +10,8 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
   # Should the event's metadata be included?
   config :metadata, :validate => :boolean, :default => false
 
-  AMAZING_OPTIONS = {:color => {:logstash_timestamp => :green}}
+  # AMAZING_OPTIONS = {:color => {:logstash_timestamp => :green}}
+  AMAZING_OPTIONS = {}
 
   def register
     require "amazing_print"

--- a/lib/logstash/codecs/rubydebug.rb
+++ b/lib/logstash/codecs/rubydebug.rb
@@ -2,7 +2,7 @@
 require "logstash/codecs/base"
 
 # The rubydebug codec will output your Logstash event data using
-# the Ruby Awesome Print library.
+# the Ruby Amazing Print library.
 #
 class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
   config_name "rubydebug"
@@ -10,13 +10,11 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
   # Should the event's metadata be included?
   config :metadata, :validate => :boolean, :default => false
 
-  # AWESOME_OPTIONS = {:color => {:logstash_timestamp => :green}}
-  # disabled options, awesome_print coloring option is buggy and only occurs once and it cannot be tested.
-  AWESOME_OPTIONS = {}
+  AMAZING_OPTIONS = {:color => {:logstash_timestamp => :green}}
 
   def register
-    require "awesome_print"
-    AwesomePrint.defaults = AWESOME_OPTIONS
+    require "amazing_print"
+    AmazingPrint.defaults = AMAZING_OPTIONS
 
     if @metadata
       @encoder = method(:encode_with_metadata)
@@ -36,11 +34,11 @@ class LogStash::Codecs::RubyDebug < LogStash::Codecs::Base
   end
 
   def encode_default(event)
-    @on_event.call(event, event.to_hash.awesome_inspect + NL)
+    @on_event.call(event, event.to_hash.ai + NL)
   end # def encode_default
 
   def encode_with_metadata(event)
-    @on_event.call(event, event.to_hash_with_metadata.awesome_inspect + NL)
+    @on_event.call(event, event.to_hash_with_metadata.ai + NL)
   end # def encode_with_metadata
 
 end # class LogStash::Codecs::Dots

--- a/logstash-codec-rubydebug.gemspec
+++ b/logstash-codec-rubydebug.gemspec
@@ -1,9 +1,9 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-rubydebug'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
-  s.summary         = "Applies the Ruby Awesome Print library to Logstash events"
+  s.summary         = "Applies the Ruby Amazing Print library to Logstash events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]
   s.email           = 'info@elastic.co'
@@ -22,13 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
-  # 2018-06-04: as of this writing, the latest release of awesome_print (v1.8.0) contains a bug that causes the Logstash
-  # process to crash while loading this dependency if an exception is raised attempting to load defaults (e.g., when
-  # `ENV['HOME']` is unset or the JVM doesn't have permission to read the `.aprc` file at that address).
-  #
-  # Pin to 1.7.0 until the already-fixed code on awesome_print's master branch finds its way to a release.
-  # SEE: https://github.com/awesome-print/awesome_print/issues/338
-  s.add_runtime_dependency 'awesome_print', '1.7.0'
+  s.add_runtime_dependency 'amazing_print', '~> 1'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/codecs/rubydebug_spec.rb
+++ b/spec/codecs/rubydebug_spec.rb
@@ -4,22 +4,6 @@ require "logstash/event"
 
 describe LogStash::Codecs::RubyDebug do
 
-  # This is a necessary monkey patch that ensures that if ActiveSupport
-  # is defined, then the on_load method exists.
-  # The awesome_print gem uses this method to hook extra funcionality if
-  # ActiveSupport is loaded. Since some versions of ActiveSupport don't
-  # have the on_load method we must ensure this method exists.
-  # More information:
-  # * https://github.com/logstash-plugins/logstash-codec-rubydebug/issues/8
-  # * https://github.com/michaeldv/awesome_print/pull/206
-  before(:all) do
-    if defined?(ActiveSupport) && !ActiveSupport.respond_to?(:on_load)
-      module ActiveSupport
-        def self.on_load(*params); end
-      end
-    end
-  end
-
   subject { LogStash::Codecs::RubyDebug.new }
 
   context "#encode" do
@@ -27,7 +11,7 @@ describe LogStash::Codecs::RubyDebug do
       subject.register
 
       event = LogStash::Event.new({"what" => "ok", "who" => 2})
-      on_event = lambda { |e, d| expect(d.chomp).to eq(event.to_hash.awesome_inspect) }
+      on_event = lambda { |e, d| expect(d.chomp).to eq(event.to_hash.ai) }
 
       subject.on_event(&on_event)
       expect(on_event).to receive(:call).once.and_call_original

--- a/spec/codecs/rubydebug_spec.rb
+++ b/spec/codecs/rubydebug_spec.rb
@@ -7,10 +7,11 @@ describe LogStash::Codecs::RubyDebug do
   subject { LogStash::Codecs::RubyDebug.new }
 
   context "#encode" do
-    it "should print beautiful hashes" do
-      subject.register
+    let(:event) { LogStash::Event.new({"what" => "ok", "who" => 2}) }
 
-      event = LogStash::Event.new({"what" => "ok", "who" => 2})
+    before(:each) { subject.register }
+
+    it "should print beautiful hashes" do
       on_event = lambda { |e, d| expect(d.chomp).to eq(event.to_hash.ai) }
 
       subject.on_event(&on_event)


### PR DESCRIPTION
the awesome_print library has become inactive and fixes weren't being released, so this PR switches to a new fork called amazing_print!

This will remove the current warning whenever this codec is used for the first time:

```
The stdin plugin is now waiting for input:
er
/private/tmp/logstash-7.8.0/vendor/bundle/jruby/2.5.0/gems/awesome_print-1.7.0/lib/awesome_print/formatters/base_formatter.rb:31: warning: constant ::Fixnum is deprecated
{
          "type" => "stdin",
       "message" => "er",
      "@version" => "1",
    "@timestamp" => 2020-07-07T10:28:22.493Z,
          "host" => "joaos-mbp.lan"
}
```